### PR TITLE
Fixes and additions for CLI and lcu creation flow

### DIFF
--- a/src/application/index.ts
+++ b/src/application/index.ts
@@ -141,6 +141,9 @@ export function updatePolyfills(host: Tree, options: any, projectName: string, c
 
 export function manageAppAssets(options: any, context: SchematicContext) {
   return (host: Tree) => {
+    context.logger.info(`manageAppAssets() init...`);
+    context.logger.info(`manageAppAssets() options - ${options}`);
+    context.logger.info(`manageAppAssets() context - ${context}`);
     let projectSafeName = strings.dasherize(options.name);
 
     let packageGlob = {
@@ -150,8 +153,10 @@ export function manageAppAssets(options: any, context: SchematicContext) {
     };
 
     let angularFile = host.get('angular.json');
+    context.logger.info(`manageAppAssets() angularFile - ${angularFile}`);
 
     let angularJson = angularFile ? JSON.parse(angularFile.content.toString('utf8')) : {};
+    context.logger.info(`manageAppAssets() angularJson before - ${angularJson}`);
 
     angularJson.projects[projectSafeName].architect.build.options.assets.push(packageGlob);
 
@@ -168,6 +173,9 @@ export function manageAppAssets(options: any, context: SchematicContext) {
         output: '/'
       });
     }
+    // TODO: Remove budgets
+    // How to log:
+    // context.logger.info(`Processing Initialization for ${options.initWith}...`);
 
     if (options.es5Patch) delete angularJson.projects[projectSafeName].architect.build.options.es5BrowserSupport;
 
@@ -178,6 +186,7 @@ export function manageAppAssets(options: any, context: SchematicContext) {
         'node_modules/@webcomponents/custom-elements/src/native-shim.js'
       );
 
+    context.logger.info(`manageAppAssets() angularJson after - ${angularJson}`);
     host.overwrite('angular.json', JSON.stringify(angularJson, null, '\t'));
 
     createPackageJson(host, options, projectSafeName, context);

--- a/src/application/index.ts
+++ b/src/application/index.ts
@@ -156,7 +156,9 @@ export function manageAppAssets(options: any, context: SchematicContext) {
     context.logger.info(`manageAppAssets() angularFile - ${JSON.stringify(angularFile)}`);
 
     let angularJson = angularFile ? JSON.parse(angularFile.content.toString('utf8')) : {};
-    context.logger.info(`manageAppAssets() angularJson before - ${JSON.stringify(angularJson)}`);
+
+    let angularJsonText = JSON.stringify(angularJson);
+    context.logger.info(`manageAppAssets() angularJson before - ${angularJsonText}`);
 
     angularJson.projects[projectSafeName].architect.build.options.assets.push(packageGlob);
 
@@ -177,7 +179,6 @@ export function manageAppAssets(options: any, context: SchematicContext) {
     // How to log:
     // context.logger.info(`Processing Initialization for ${options.initWith}...`);
 
-    delete angularJson.projects[projectSafeName].architect.build.configurations.production.budgets;
 
     if (options.es5Patch) delete angularJson.projects[projectSafeName].architect.build.options.es5BrowserSupport;
 
@@ -188,7 +189,14 @@ export function manageAppAssets(options: any, context: SchematicContext) {
         'node_modules/@webcomponents/custom-elements/src/native-shim.js'
       );
 
-    context.logger.info(`manageAppAssets() angularJson after - ${JSON.stringify(angularJson)}`);
+    context.logger.info(`manageAppAssets() deleted angular budgets...`);
+    delete angularJson.projects[projectSafeName].architect.build.configurations.production.budgets;
+    delete angularJson.projects[projectSafeName].architect.build.configurations.production.budgets;
+
+    context.logger.info(`manageAppAssets() budgets - ${angularJson.projects[projectSafeName].architect.build.configurations.production.budgets}`);
+    
+    angularJsonText = JSON.stringify(angularJson);
+    context.logger.info(`manageAppAssets() angularJson after - ${angularJsonText}`);
     host.overwrite('angular.json', JSON.stringify(angularJson, null, '\t'));
 
     createPackageJson(host, options, projectSafeName, context);

--- a/src/application/index.ts
+++ b/src/application/index.ts
@@ -143,7 +143,6 @@ export function manageAppAssets(options: any, context: SchematicContext) {
   return (host: Tree) => {
     context.logger.info(`manageAppAssets() init...`);
     context.logger.info(`manageAppAssets() options - ${JSON.stringify(options)}`);
-    context.logger.info(`manageAppAssets() context - ${JSON.stringify(context)}`);
     let projectSafeName = strings.dasherize(options.name);
 
     let packageGlob = {

--- a/src/application/index.ts
+++ b/src/application/index.ts
@@ -142,8 +142,8 @@ export function updatePolyfills(host: Tree, options: any, projectName: string, c
 export function manageAppAssets(options: any, context: SchematicContext) {
   return (host: Tree) => {
     context.logger.info(`manageAppAssets() init...`);
-    context.logger.info(`manageAppAssets() options - ${options}`);
-    context.logger.info(`manageAppAssets() context - ${context}`);
+    context.logger.info(`manageAppAssets() options - ${JSON.stringify(options)}`);
+    context.logger.info(`manageAppAssets() context - ${JSON.stringify(context)}`);
     let projectSafeName = strings.dasherize(options.name);
 
     let packageGlob = {
@@ -153,10 +153,10 @@ export function manageAppAssets(options: any, context: SchematicContext) {
     };
 
     let angularFile = host.get('angular.json');
-    context.logger.info(`manageAppAssets() angularFile - ${angularFile}`);
+    context.logger.info(`manageAppAssets() angularFile - ${JSON.stringify(angularFile)}`);
 
     let angularJson = angularFile ? JSON.parse(angularFile.content.toString('utf8')) : {};
-    context.logger.info(`manageAppAssets() angularJson before - ${angularJson}`);
+    context.logger.info(`manageAppAssets() angularJson before - ${JSON.stringify(angularJson)}`);
 
     angularJson.projects[projectSafeName].architect.build.options.assets.push(packageGlob);
 
@@ -177,6 +177,8 @@ export function manageAppAssets(options: any, context: SchematicContext) {
     // How to log:
     // context.logger.info(`Processing Initialization for ${options.initWith}...`);
 
+    delete angularJson.projects[projectSafeName].architect.build.configurations.production.budgets;
+
     if (options.es5Patch) delete angularJson.projects[projectSafeName].architect.build.options.es5BrowserSupport;
 
     if (options.es5Patch) delete angularJson.projects[projectSafeName].architect.build.options.es5BrowserSupport;
@@ -186,7 +188,7 @@ export function manageAppAssets(options: any, context: SchematicContext) {
         'node_modules/@webcomponents/custom-elements/src/native-shim.js'
       );
 
-    context.logger.info(`manageAppAssets() angularJson after - ${angularJson}`);
+    context.logger.info(`manageAppAssets() angularJson after - ${JSON.stringify(angularJson)}`);
     host.overwrite('angular.json', JSON.stringify(angularJson, null, '\t'));
 
     createPackageJson(host, options, projectSafeName, context);

--- a/src/application/index.ts
+++ b/src/application/index.ts
@@ -141,8 +141,6 @@ export function updatePolyfills(host: Tree, options: any, projectName: string, c
 
 export function manageAppAssets(options: any, context: SchematicContext) {
   return (host: Tree) => {
-    context.logger.info(`manageAppAssets() init...`);
-    context.logger.info(`manageAppAssets() options - ${JSON.stringify(options)}`);
     let projectSafeName = strings.dasherize(options.name);
 
     let packageGlob = {
@@ -152,12 +150,10 @@ export function manageAppAssets(options: any, context: SchematicContext) {
     };
 
     let angularFile = host.get('angular.json');
-    context.logger.info(`manageAppAssets() angularFile - ${JSON.stringify(angularFile)}`);
 
     let angularJson = angularFile ? JSON.parse(angularFile.content.toString('utf8')) : {};
 
     let angularJsonText = JSON.stringify(angularJson);
-    context.logger.info(`manageAppAssets() angularJson before - ${angularJsonText}`);
 
     angularJson.projects[projectSafeName].architect.build.options.assets.push(packageGlob);
 
@@ -174,10 +170,6 @@ export function manageAppAssets(options: any, context: SchematicContext) {
         output: '/'
       });
     }
-    // TODO: Remove budgets
-    // How to log:
-    // context.logger.info(`Processing Initialization for ${options.initWith}...`);
-
 
     if (options.es5Patch) delete angularJson.projects[projectSafeName].architect.build.options.es5BrowserSupport;
 
@@ -188,14 +180,8 @@ export function manageAppAssets(options: any, context: SchematicContext) {
         'node_modules/@webcomponents/custom-elements/src/native-shim.js'
       );
 
-    context.logger.info(`manageAppAssets() deleted angular budgets...`);
-    delete angularJson.projects[projectSafeName].architect.build.configurations.production.budgets;
     delete angularJson.projects[projectSafeName].architect.build.configurations.production.budgets;
 
-    context.logger.info(`manageAppAssets() budgets - ${angularJson.projects[projectSafeName].architect.build.configurations.production.budgets}`);
-    
-    angularJsonText = JSON.stringify(angularJson);
-    context.logger.info(`manageAppAssets() angularJson after - ${angularJsonText}`);
     host.overwrite('angular.json', JSON.stringify(angularJson, null, '\t'));
 
     createPackageJson(host, options, projectSafeName, context);

--- a/src/collection.json
+++ b/src/collection.json
@@ -56,6 +56,10 @@
     "blah": {
       "description": "A blank schematic.",
       "factory": "./blah/index#blah"
+    },
+    "module": {
+      "description": "Schematic to add a Angular module to a specific project.",
+      "factory": "./module/index#module"
     }
   }
 }

--- a/src/lcu-form/files/src/app/app.module.ts
+++ b/src/lcu-form/files/src/app/app.module.ts
@@ -3,7 +3,7 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 // import { FlexLayoutModule } from '@angular/flex-layout';
 import { AppComponent } from './app.component';
 import { FormComponent } from './controls/form/form.component';
-import { FathymSharedModule, MaterialModule } from '@lcu-ide/common';
+import { FathymSharedModule, MaterialModule } from '@lcu/common';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 
 @NgModule({

--- a/src/lcu-form/files/src/app/controls/form/form.component.ts
+++ b/src/lcu-form/files/src/app/controls/form/form.component.ts
@@ -7,7 +7,7 @@ import { ReactiveFormModel } from './../../models/reactive-form.model';
 import { Observable } from 'rxjs/internal/Observable';
 import { map } from 'rxjs/internal/operators/map';
 import { Subscription } from 'rxjs/internal/Subscription';
-import { PasswordValidator, EmailValidator, UserNameValidator, ValidationMessages, ZipcodeValidator } from '@lcu-ide/common';
+import { PasswordValidator, EmailValidator, UserNameValidator, ValidationMessages, ZipcodeValidator } from '@lcu/common';
 import { startWith } from 'rxjs/operators';
 
 

--- a/src/lcu/index.ts
+++ b/src/lcu/index.ts
@@ -94,7 +94,7 @@ export function addScripts(options: any) {
       },
       {
         key: `pack:main`,
-        value: `concat-glob-cli -f \"dist/lcu/main.*.js\" -o dist/lcu/wc/lcu.startup.js`
+        value: `concat-glob-cli -f \"dist/lcu/main-es2015.*.js\" -o dist/lcu/wc/lcu.startup.js`
       },
       {
         key: `pack:pollyfills`,

--- a/src/library/index.ts
+++ b/src/library/index.ts
@@ -29,12 +29,19 @@ export function library(options: any): Rule {
     setupOptions(host, options);
 
     const rule = chain([
-      branchAndMerge(externalSchematic('@schematics/angular', 'library', {
-        name: options.name,
-        entryFile: options.entryFile,
-        prefix: options.prefix,
-        skipInstall: true
-      })),
+      branchAndMerge(
+        externalSchematic('@schematics/angular', 'library', {
+          name: options.name,
+          entryFile: options.entryFile,
+          prefix: options.prefix,
+          skipInstall: true
+        }),
+        externalSchematic('@schematics/angular', 'module', {
+          name: `${options.workspace}`,
+          project: options.name ? options.name : 'common',
+          flat: true
+        })
+      ),
       processInitWith(options, context),
       addDeployScripts(options),
       manageDeployAllScript(options),

--- a/src/library/index.ts
+++ b/src/library/index.ts
@@ -35,7 +35,12 @@ export function library(options: any): Rule {
         prefix: options.prefix,
         skipInstall: true
       })),
-      externalSchematic('@schematics/angular', 'module', {
+      // externalSchematic('@schematics/angular', 'module', {
+      //   name: `${options.workspace}`,
+      //   project: options.name ? options.name : 'common',
+      //   flat: true
+      // }),
+      schematic('module', {
         name: `${options.workspace}`,
         project: options.name ? options.name : 'common',
         flat: true

--- a/src/library/index.ts
+++ b/src/library/index.ts
@@ -27,11 +27,6 @@ export function library(options: any): Rule {
         prefix: options.prefix,
         skipInstall: true
       })),
-      schematic('module', {
-        name: options.workspace,
-        project: options.name,
-        flat: true
-      }),
       processInitWith(options, context),
       addDeployScripts(options),
       manageDeployAllScript(options),

--- a/src/library/index.ts
+++ b/src/library/index.ts
@@ -29,19 +29,17 @@ export function library(options: any): Rule {
     setupOptions(host, options);
 
     const rule = chain([
-      branchAndMerge(
-        externalSchematic('@schematics/angular', 'library', {
-          name: options.name,
-          entryFile: options.entryFile,
-          prefix: options.prefix,
-          skipInstall: true
-        }),
-        externalSchematic('@schematics/angular', 'module', {
-          name: `${options.workspace}`,
-          project: options.name ? options.name : 'common',
-          flat: true
-        })
-      ),
+      branchAndMerge(externalSchematic('@schematics/angular', 'library', {
+        name: options.name,
+        entryFile: options.entryFile,
+        prefix: options.prefix,
+        skipInstall: true
+      })),
+      externalSchematic('@schematics/angular', 'module', {
+        name: `${options.workspace}`,
+        project: options.name ? options.name : 'common',
+        flat: true
+      }),
       processInitWith(options, context),
       addDeployScripts(options),
       manageDeployAllScript(options),

--- a/src/library/index.ts
+++ b/src/library/index.ts
@@ -1,32 +1,24 @@
 import { getWorkspace } from '@schematics/angular/utility/config';
 import { NodePackageInstallTask } from '@angular-devkit/schematics/tasks';
-import { buildDefaultPath } from '@schematics/angular/utility/project';
-import { parseName } from '@schematics/angular/utility/parse-name';
 import {
   Rule,
   SchematicContext,
   Tree,
-  apply,
-  url,
   noop,
-  filter,
-  move,
-  MergeStrategy,
-  mergeWith,
-  template,
   chain,
   externalSchematic,
   branchAndMerge,
   schematic
 } from '@angular-devkit/schematics';
-import { ProjectType, WorkspaceProject } from '@schematics/angular/utility/workspace-models';
-import { normalize, strings, Path, join } from '@angular-devkit/core';
+import { strings, Path, join } from '@angular-devkit/core';
 import { addScriptsToPackageFile } from '../utils/helpers';
-import { Logger } from '@angular-devkit/core/src/logger';
 
 export function library(options: any): Rule {
   return (host: Tree, context: SchematicContext) => {
+    context.logger.info(`BOBBY 5570 - library() intialized...`);
     setupOptions(host, options);
+    context.logger.info(`BOBBY 5570 - library() options.name: ${options.name}`);
+    context.logger.info(`BOBBY 5570 - library() options.workspace: ${options.workspace}`);
 
     const rule = chain([
       branchAndMerge(externalSchematic('@schematics/angular', 'library', {
@@ -35,14 +27,9 @@ export function library(options: any): Rule {
         prefix: options.prefix,
         skipInstall: true
       })),
-      // externalSchematic('@schematics/angular', 'module', {
-      //   name: `${options.workspace}`,
-      //   project: options.name ? options.name : 'common',
-      //   flat: true
-      // }),
       schematic('module', {
-        name: `${options.workspace}`,
-        project: options.name ? options.name : 'common',
+        name: options.workspace,
+        project: options.name,
         flat: true
       }),
       processInitWith(options, context),

--- a/src/library/index.ts
+++ b/src/library/index.ts
@@ -15,10 +15,7 @@ import { addScriptsToPackageFile } from '../utils/helpers';
 
 export function library(options: any): Rule {
   return (host: Tree, context: SchematicContext) => {
-    context.logger.info(`BOBBY 5570 - library() intialized...`);
     setupOptions(host, options);
-    context.logger.info(`BOBBY 5570 - library() options.name: ${options.name}`);
-    context.logger.info(`BOBBY 5570 - library() options.workspace: ${options.workspace}`);
 
     const rule = chain([
       branchAndMerge(externalSchematic('@schematics/angular', 'library', {

--- a/src/module/files/__name@dasherize__.module.ts
+++ b/src/module/files/__name@dasherize__.module.ts
@@ -1,0 +1,17 @@
+import { NgModule } from '@angular/core';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { FlexLayoutModule } from '@angular/flex-layout';
+import { FathymSharedModule } from '@lcu/common';
+
+@NgModule({
+  declarations: [],
+  imports: [
+    FathymSharedModule,
+    FormsModule,
+    ReactiveFormsModule,
+    FlexLayoutModule
+  ],
+  export: [],
+  entryComponents: []
+})
+export class <%= classify(workspace) %>Module { }

--- a/src/module/files/__name@dasherize__.module.ts
+++ b/src/module/files/__name@dasherize__.module.ts
@@ -11,7 +11,7 @@ import { FathymSharedModule } from '@lcu/common';
     ReactiveFormsModule,
     FlexLayoutModule
   ],
-  export: [],
+  exports: [],
   entryComponents: []
 })
-export class <%= classify(workspace) %>Module { }
+export class <%= classify(name) %>Module { }

--- a/src/module/files/app/app.module.ts
+++ b/src/module/files/app/app.module.ts
@@ -1,0 +1,15 @@
+import { NgModule } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { FathymSharedModule } from '@lcu/common';
+
+@NgModule({
+  declarations: [],
+  imports: [
+    BrowserModule,
+    BrowserAnimationsModule,
+    FathymSharedModule
+  ],
+  exports: []
+})
+export class AppModule {}

--- a/src/module/files/component/__name@dasherize__.module.ts
+++ b/src/module/files/component/__name@dasherize__.module.ts
@@ -14,4 +14,4 @@ import { FathymSharedModule } from '@lcu/common';
   exports: [],
   entryComponents: []
 })
-export class <%= classify(name) %>Module { }
+export class <%= classify(name) %>Module {}

--- a/src/module/index.ts
+++ b/src/module/index.ts
@@ -14,27 +14,21 @@ import { normalize, strings } from '@angular-devkit/core';
 
 export function module(options: any): Rule {
     return (host: Tree, context: SchematicContext) => {
-      context.logger.info(`BOBBY 5570 - module() initialized...`);
+      context.logger.debug('Starting module...');
+
       setupOptions(host, options);
-      context.logger.info(`BOBBY 5570 - module() options: ${JSON.stringify(options)}`);
   
       const workspace = getWorkspace(host);
-
       const project = workspace.projects[options.project];
-      context.logger.info(`BOBBY 5570 - module() project: ${JSON.stringify(project)}`);
-
       const targetPath = normalize(project.root + '/src/' + options.path);
-      context.logger.info(`BOBBY 5570 - module() targetPath: ${targetPath}`);
 
       let filePath: string = './files';
-      context.logger.info(`BOBBY 5570 - module() filePath before: ${filePath}`);
 
       if (options.initWith === 'app') {
         filePath += '/app';
       } else {
         filePath += '/component';
       }
-      context.logger.info(`BOBBY 5570 - module() filePath after: ${filePath}`);
       
       const solutionSource = apply(url(filePath), [
         template({

--- a/src/module/index.ts
+++ b/src/module/index.ts
@@ -42,7 +42,6 @@ export function module(options: any): Rule {
 }
   
 function setupOptions(host: Tree, options: any): Tree {
-    context.logger.info(`BOBBY 5570 - setupOptions() initialized...`);
     var lcuFile = host.get('lcu.json');
   
     var lcuJson = lcuFile ? JSON.parse(lcuFile.content.toString('utf8')) : {};

--- a/src/module/index.ts
+++ b/src/module/index.ts
@@ -1,0 +1,71 @@
+import { getWorkspace } from '@schematics/angular/utility/config';
+import {
+  Rule,
+  SchematicContext,
+  Tree,
+  apply,
+  url,
+  noop,
+  filter,
+  move,
+  MergeStrategy,
+  mergeWith,
+  template,
+  chain
+} from '@angular-devkit/schematics';
+import { normalize, strings } from '@angular-devkit/core';
+
+export function module(options: any): Rule {
+    return (host: Tree, context: SchematicContext) => {
+      context.logger.info(`BOBBY 5570 - module() initialized...`);
+      setupOptions(host, options);
+  
+      const workspace = getWorkspace(host);
+      const project = workspace.projects[options.project];
+    //   const targetPath = normalize(project.root + '/src/' + options.path);
+      const targetPath = normalize(project.root + '/src/lib/');
+      context.logger.info(`BOBBY 5570 - module() targetPath: ${targetPath}`);
+      const solutionSource = apply(url('./files'), [
+        template({
+          ...strings,
+          ...options
+        }),
+        move(targetPath)
+      ]);
+  
+    //   return chain([
+    //     mergeWith(solutionSource, MergeStrategy.Default),
+    //     !options.export ? noop() : prepareLcuApiExport(project, options)
+    //   ]);
+      return mergeWith(solutionSource, MergeStrategy.Overwrite);
+    };
+}
+  
+function setupOptions(host: Tree, options: any): Tree {
+    context.logger.info(`BOBBY 5570 - setupOptions() initialized...`);
+    var lcuFile = host.get('lcu.json');
+  
+    var lcuJson = lcuFile ? JSON.parse(lcuFile.content.toString('utf8')) : {};
+  
+    const workspace = getWorkspace(host);
+  
+    options.scope = lcuJson.templates.scope;
+  
+    options.workspace = lcuJson.templates.workspace;
+  
+    options.project = options.project
+      ? options.project
+      : workspace.defaultProject
+      ? <string>workspace.defaultProject
+      : Object.keys(workspace.projects)[0];
+  
+    options.path = options.path || 'lib/elements';
+  
+    options.export = options.export || 'src/lcu.api.ts';
+  
+    options.name = options.name || 'solution';
+  
+    options.spec = options.spec || false;
+  
+    return host;
+}

--- a/src/module/index.ts
+++ b/src/module/index.ts
@@ -5,13 +5,10 @@ import {
   Tree,
   apply,
   url,
-  noop,
-  filter,
   move,
   MergeStrategy,
   mergeWith,
-  template,
-  chain
+  template
 } from '@angular-devkit/schematics';
 import { normalize, strings } from '@angular-devkit/core';
 
@@ -20,7 +17,6 @@ export function module(options: any): Rule {
       context.logger.info(`BOBBY 5570 - module() initialized...`);
       setupOptions(host, options);
       context.logger.info(`BOBBY 5570 - module() options: ${JSON.stringify(options)}`);
-      context.logger.info(`BOBBY 5570 - module() options.name: ${options.name}`);
   
       const workspace = getWorkspace(host);
 
@@ -30,7 +26,17 @@ export function module(options: any): Rule {
       const targetPath = normalize(project.root + '/src/' + options.path);
       context.logger.info(`BOBBY 5570 - module() targetPath: ${targetPath}`);
 
-      const solutionSource = apply(url('./files'), [
+      let filePath: string = './files';
+      context.logger.info(`BOBBY 5570 - module() filePath before: ${filePath}`);
+
+      if (options.initWith === 'app') {
+        filePath += '/app';
+      } else {
+        filePath += '/component';
+      }
+      context.logger.info(`BOBBY 5570 - module() filePath after: ${filePath}`);
+      
+      const solutionSource = apply(url(filePath), [
         template({
           ...strings,
           ...options

--- a/src/module/index.ts
+++ b/src/module/index.ts
@@ -19,12 +19,17 @@ export function module(options: any): Rule {
     return (host: Tree, context: SchematicContext) => {
       context.logger.info(`BOBBY 5570 - module() initialized...`);
       setupOptions(host, options);
+      context.logger.info(`BOBBY 5570 - module() options: ${JSON.stringify(options)}`);
+      context.logger.info(`BOBBY 5570 - module() options.name: ${options.name}`);
   
       const workspace = getWorkspace(host);
+
       const project = workspace.projects[options.project];
-    //   const targetPath = normalize(project.root + '/src/' + options.path);
-      const targetPath = normalize(project.root + '/src/lib/');
+      context.logger.info(`BOBBY 5570 - module() project: ${JSON.stringify(project)}`);
+
+      const targetPath = normalize(project.root + '/src/' + options.path);
       context.logger.info(`BOBBY 5570 - module() targetPath: ${targetPath}`);
+
       const solutionSource = apply(url('./files'), [
         template({
           ...strings,
@@ -33,10 +38,6 @@ export function module(options: any): Rule {
         move(targetPath)
       ]);
   
-    //   return chain([
-    //     mergeWith(solutionSource, MergeStrategy.Default),
-    //     !options.export ? noop() : prepareLcuApiExport(project, options)
-    //   ]);
       return mergeWith(solutionSource, MergeStrategy.Overwrite);
     };
 }
@@ -58,7 +59,7 @@ function setupOptions(host: Tree, options: any): Tree {
       ? <string>workspace.defaultProject
       : Object.keys(workspace.projects)[0];
   
-    options.path = options.path || 'lib/elements';
+    options.path = options.path || 'lib';
   
     options.export = options.export || 'src/lcu.api.ts';
   

--- a/src/ng-add/files/project/lcu.json
+++ b/src/ng-add/files/project/lcu.json
@@ -8,7 +8,7 @@
     "wc": ["wc/<%= workspace %>.lcu.js"],
     "solutions": {},
     "elements": {},
-    "flux": {},
+    "data-flow": {},
     "dependencies": {}
   }
 }

--- a/src/solution/files/default/__name@dasherize__/__name@dasherize__.component.ts
+++ b/src/solution/files/default/__name@dasherize__/__name@dasherize__.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, Injector } from '@angular/core';
-import { LCUElementContext, LcuElementComponent } from '@lcu-ide/common';
+import { LCUElementContext, LcuElementComponent } from '@lcu/common';
 
 export class <%= classify(workspace) %><%= classify(name) %>ElementState {}
 

--- a/src/solution/index.ts
+++ b/src/solution/index.ts
@@ -14,7 +14,7 @@ import {
   template,
   chain
 } from '@angular-devkit/schematics';
-import { findModuleFromOptions } from '@schematics/angular/utility/find-module';
+import { findModuleFromOptions, buildRelativePath } from '@schematics/angular/utility/find-module';
 import { branchAndMerge } from '@angular-devkit/schematics';
 import { parseName } from '@schematics/angular/utility/parse-name';
 import { normalize, strings } from '@angular-devkit/core';
@@ -52,13 +52,20 @@ export function solution(options: any): Rule {
 
 function prepareLcuApiExport(project: WorkspaceProject<ProjectType>, options: any) {
   return (host: Tree) => {
-    var exportFile = normalize(project.root + '/' + options.export);
+    const exportFile = normalize('/' + project.root + '/' + options.export);
 
     const textBuf = host.read(exportFile);
 
-    var text = textBuf ? textBuf.toString('utf8') : '';
+    const componentPath = `${options.path}/`
+    + strings.dasherize(options.name) + '/'
+    + strings.dasherize(options.name)
+    + '.component';
 
-    var newExport = `export * from './${options.path}/${strings.dasherize(options.name)}/${strings.dasherize(options.name)}.component';`;
+    const relativePath = buildRelativePath(exportFile, componentPath);
+
+    let text = textBuf ? textBuf.toString('utf8') : '';
+
+    let newExport = `export * from '${relativePath}';`;
 
     if (text.indexOf(newExport) < 0) {
       text += `${newExport}\r\n`;

--- a/src/solution/index.ts
+++ b/src/solution/index.ts
@@ -18,7 +18,14 @@ import { normalize, strings } from '@angular-devkit/core';
 
 export function solution(options: any): Rule {
   return (host: Tree, context: SchematicContext) => {
+    context.logger.info(`BOBBY 5570 - solution() initialized...`);
+
     setupOptions(host, options);
+
+    context.logger.info(`BOBBY 5570 - solution() adding solution capabilities...`);
+    addSolutionCapabilities(host, options);
+
+    context.logger.info(`BOBBY 5570 - solution() successfully added solution capabilities...`);
 
     const workspace = getWorkspace(host);
 
@@ -86,6 +93,24 @@ function setupOptions(host: Tree, options: any): Tree {
   options.name = options.name || 'solution';
 
   options.spec = options.spec || false;
+
+  return host;
+}
+
+function addSolutionCapabilities(host: Tree, options: any): Tree {
+  var lcuFile = host.get('lcu.json');
+
+  var lcuJson = lcuFile ? JSON.parse(lcuFile.content.toString('utf8')) : {};
+
+  let capabilityName: string = options.project + '-manager'; // TODO: Do we want users to provide this?
+
+  let elementName: string = lcuJson.templates.workspace + '-' + options.project + '-element';
+
+  lcuJson.config.solutions[capabilityName] = {
+    element: elementName
+  };
+  
+  host.overwrite('lcu.json', JSON.stringify(lcuJson, null, '\t'));
 
   return host;
 }

--- a/src/solution/index.ts
+++ b/src/solution/index.ts
@@ -22,7 +22,7 @@ import { addSolutionToNgModule } from '../utils/module-helpers';
 
 export function solution(options: any): Rule {
   return (host: Tree, context: SchematicContext) => {
-    context.logger.info(`BOBBY 5570 - solution() initialized... options: ${JSON.stringify(options)}`);
+    context.logger.debug('Starting solution...');
 
     setupOptions(host, options);
     addSolutionCapabilities(host, options);

--- a/src/solution/index.ts
+++ b/src/solution/index.ts
@@ -98,11 +98,10 @@ function setupOptions(host: Tree, options: any): Tree {
 }
 
 function addSolutionCapabilities(host: Tree, options: any): Tree {
-  var lcuFile = host.get('lcu.json');
+  let lcuFile = host.get('lcu.json');
 
-  var lcuJson = lcuFile ? JSON.parse(lcuFile.content.toString('utf8')) : {};
+  let lcuJson = lcuFile ? JSON.parse(lcuFile.content.toString('utf8')) : {};
 
-  // TODO: 'options.project' is wrong name (coming back as 'common') - find the right name
   let capabilityName: string = options.name + '-manager'; // TODO: Do we want users to provide this?
 
   let elementName: string = lcuJson.templates.workspace + '-' + options.name + '-element';

--- a/src/solution/index.ts
+++ b/src/solution/index.ts
@@ -102,9 +102,10 @@ function addSolutionCapabilities(host: Tree, options: any): Tree {
 
   var lcuJson = lcuFile ? JSON.parse(lcuFile.content.toString('utf8')) : {};
 
-  let capabilityName: string = options.project + '-manager'; // TODO: Do we want users to provide this?
+  // TODO: 'options.project' is wrong name (coming back as 'common') - find the right name
+  let capabilityName: string = options.name + '-manager'; // TODO: Do we want users to provide this?
 
-  let elementName: string = lcuJson.templates.workspace + '-' + options.project + '-element';
+  let elementName: string = lcuJson.templates.workspace + '-' + options.name + '-element';
 
   lcuJson.config.solutions[capabilityName] = {
     element: elementName

--- a/src/utils/module-helpers.ts
+++ b/src/utils/module-helpers.ts
@@ -28,13 +28,11 @@ export class AddToModuleContext {
  */
 export function addSolutionToNgModule(options: ModuleOptions | any): Rule {
   return (host: Tree) => {
-    console.log('addSolutionToNgModule initializing...');
     addDeclaration(host, createAddToModuleContext(host, options));
     addExport(host, createAddToModuleContext(host, options));
     addEntryComponent(host, createAddToModuleContext(host, options));
 
     if (!options.disableLcuBootstrap) {
-      console.log('adding custom bootstrapper...');
       addCustomLcuBootstrap(host, options);
     }
     return host;
@@ -48,7 +46,6 @@ export function addSolutionToNgModule(options: ModuleOptions | any): Rule {
  */
 export function updateAppModule(options: ModuleOptions): Rule {
   return (host: Tree) => {
-    console.log('updateAppModule initializing...');
     addImport(host, createUpdateModuleContext(host, options));
     addExport(host, createUpdateModuleContext(host, options));
     return host;
@@ -62,7 +59,6 @@ export function updateAppModule(options: ModuleOptions): Rule {
  * @param options The options passed from the calling command
  */
 function addCustomLcuBootstrap(host: Tree, options: ModuleOptions | any): void {
-  console.log('addCustomLcuBootstrap initializing...');
   let component = stringUtils.classify(`${options.workspace}`) + stringUtils.classify(`${options.name}ElementComponent`);
   let selector = 'Selector' + stringUtils.classify(`${options.workspace}`) + stringUtils.classify(`${options.name}Element`);
 
@@ -110,8 +106,6 @@ function addCustomLcuBootstrap(host: Tree, options: ModuleOptions | any): void {
  * @param context The context containing data relating to module
  */
 function addDeclaration(host: Tree, context: AddToModuleContext): void {
-  console.log('addDeclaration initializing...');
-
   const declarationChanges = addDeclarationToModule(
     context.source,
     context.filePath,
@@ -135,8 +129,6 @@ function addDeclaration(host: Tree, context: AddToModuleContext): void {
  * @param context The context containing data relating to module
  */
 function addEntryComponent(host: Tree, context: AddToModuleContext): void {
-  console.log('addEntryComponent initializing...');
-
   const entryComponentChanges = addEntryComponentToModule(
     context.source,
     context.filePath,
@@ -160,8 +152,6 @@ function addEntryComponent(host: Tree, context: AddToModuleContext): void {
  * @param context The context containing data relating to module
  */
 function addExport(host: Tree, context: AddToModuleContext): void {
-  console.log('addExport initializing...');
-
   const exportChanges = addExportToModule(
     context.source,
     context.filePath,
@@ -185,8 +175,6 @@ function addExport(host: Tree, context: AddToModuleContext): void {
  * @param context The context containing data relating to module
  */
 function addImport(host: Tree, context: AddToModuleContext): void {
-  console.log('addImport initializing...');
-  
   const importChanges = addImportToModule(
     context.source,
     context.filePath,
@@ -220,22 +208,17 @@ function constructWorkspacePath(options: any, project?: string): string {
  * @param options The options passed from the calling command
  */
 function createAddToModuleContext(host: Tree, options: ModuleOptions | any): AddToModuleContext {
-  console.log('createAddToModuleContext initializing...');
   const result = new AddToModuleContext();
 
   result.filePath = options.module || ''; 
-  console.log('createAddToModuleContext result.filePath:', result.filePath);
-
   result.classifiedName = stringUtils.classify(`${options.workspace}`) + stringUtils.classify(`${options.name}ElementComponent`);
 
   const componentPath = `${options.path}/`
   + stringUtils.dasherize(options.name) + '/'
   + stringUtils.dasherize(options.name)
   + '.component';
-  console.log('createAddToModuleContext componentPath:', componentPath);  
 
   result.relativePath = buildRelativePath(result.filePath, componentPath);
-  console.log('createAddToModuleContext result.relativePath:', result.relativePath);
 
   const text = host.read(result.filePath);
   if (!text) throw new SchematicsException(`File ${result.filePath} does not exist.`);
@@ -252,7 +235,6 @@ function createAddToModuleContext(host: Tree, options: ModuleOptions | any): Add
  * @param options The options passed from the calling command
  */
 function createUpdateModuleContext(host: Tree, options: ModuleOptions | any): AddToModuleContext {
-  console.log('createUpdateModuleContext initializing...');
   const result = new AddToModuleContext();
 
   result.filePath = findFileByName('app.module.ts', '/projects/lcu/src/lib', host);

--- a/src/utils/module-helpers.ts
+++ b/src/utils/module-helpers.ts
@@ -1,0 +1,122 @@
+import * as ts from 'typescript';
+import {
+  Rule,
+  Tree,
+  SchematicsException
+} from '@angular-devkit/schematics';
+import { buildRelativePath, ModuleOptions } from '@schematics/angular/utility/find-module';
+import { addDeclarationToModule, addExportToModule, addEntryComponentToModule } from '@schematics/angular/utility/ast-utils';
+import { InsertChange } from '@schematics/angular/utility/change';
+import { strings } from '@angular-devkit/core';
+
+const { dasherize, classify } = strings;
+const stringUtils = { dasherize, classify };
+
+export class AddToModuleContext {
+  source: any;
+  relativePath: string;
+  classifiedName: string;
+}
+
+export function addSolutionToNgModule(options: ModuleOptions): Rule {
+  return (host: Tree) => {
+    addDeclaration(host, options);
+    addExport(host, options);
+    addEntryComponent(host, options);
+    return host;
+  };
+}
+
+function createAddToModuleContext(host: Tree, options: ModuleOptions): AddToModuleContext {
+
+  const result = new AddToModuleContext();
+
+  if (!options.module) {
+    throw new SchematicsException(`Module not found.`);
+  }
+
+  const text = host.read(options.module);
+
+  if (text === null) {
+    throw new SchematicsException(`File ${options.module} does not exist!`);
+  }
+  const sourceText = text.toString('utf-8');
+  result.source = ts.createSourceFile(options.module, sourceText, ts.ScriptTarget.Latest, true);
+
+  const componentPath = `${options.path}/`
+    + stringUtils.dasherize(options.name) + '/'
+    + stringUtils.dasherize(options.name)
+    + '.component';
+
+  result.relativePath = buildRelativePath(options.module, componentPath);
+
+  // TODO: Get workspace in a cleaner manner
+  let lcuFile = host.get('lcu.json');
+  let lcuJson = lcuFile ? JSON.parse(lcuFile.content.toString('utf8')) : {};
+  let workspace = lcuJson.templates.workspace;
+
+  result.classifiedName = stringUtils.classify(`${workspace}`) + stringUtils.classify(`${options.name}ElementComponent`);
+  return result;
+
+}
+
+function addDeclaration(host: Tree, options: ModuleOptions) {
+
+  const context = createAddToModuleContext(host, options);
+  const modulePath = options.module || '';
+
+  const declarationChanges = addDeclarationToModule(
+    context.source,
+    modulePath,
+    context.classifiedName,
+    context.relativePath);
+
+  const declarationRecorder = host.beginUpdate(modulePath);
+
+  for (const change of declarationChanges) {
+    if (change instanceof InsertChange) {
+      declarationRecorder.insertLeft(change.pos, change.toAdd);
+    }
+  }
+  host.commitUpdate(declarationRecorder);
+};
+
+function addExport(host: Tree, options: ModuleOptions) {
+  const context = createAddToModuleContext(host, options);
+  const modulePath = options.module || '';
+
+  const exportChanges = addExportToModule(
+    context.source,
+    modulePath,
+    context.classifiedName,
+    context.relativePath);
+
+  const exportRecorder = host.beginUpdate(modulePath);
+
+  for (const change of exportChanges) {
+    if (change instanceof InsertChange) {
+      exportRecorder.insertLeft(change.pos, change.toAdd);
+    }
+  }
+  host.commitUpdate(exportRecorder);
+};
+
+function addEntryComponent(host: Tree, options: ModuleOptions) {
+  const context = createAddToModuleContext(host, options);
+  const modulePath = options.module || '';
+
+  const entryComponentChanges = addEntryComponentToModule(
+    context.source,
+    modulePath,
+    context.classifiedName,
+    context.relativePath);
+
+  const entryComponentRecorder = host.beginUpdate(modulePath);
+
+  for (const change of entryComponentChanges) {
+    if (change instanceof InsertChange) {
+      entryComponentRecorder.insertLeft(change.pos, change.toAdd);
+    }
+  }
+  host.commitUpdate(entryComponentRecorder);
+};


### PR DESCRIPTION
Patch notes:
- Update to package.json to add 'main-es2015' to 'pack:main' command.
- Override '@lcu-ide/common' refs to '@lcu/common'.
- Remove budgets from angular.json file.
- Changed 'flux' to 'data-flow' in lcu.json file.
- When solutions are generated (with 'solution' command), they are now added to the 'solutions' object in the lcu.json file.
- Added new 'module' command for creating modules and added to specific projects.
- When solutions are generated, they are now automatically added to respective module with an option to directly bootstrap them in the app.module file.
- Code cleanup and organization.